### PR TITLE
feat: add modern browser preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,24 @@ Then add an [`extends`](https://www.typescriptlang.org/tsconfig#extends) to your
 }
 ```
 
+
 ## Available configs
 
-### Generic ones
+### Base ones
 
 * [`base-node-bare`](base-node-bare.json) – where most of the configuration is set (Node.js focused)
-* [`base-node-jsdoc`](base-node-jsdoc.json) – adds JSDoc related config to `base-node-bare`
+* [`base-jsdoc`](base-jsdoc.json) – adds JSDoc related config (now shared by both Node and Browser bases)
+* [`base-node-jsdoc`](base-node-jsdoc.json) – combines `base-node-bare` and `base-jsdoc` for Node.js+JSDoc
+* [`base-browser-bare`](base-browser-bare.json) – base config for browser environments
+* [`base-browser-jsdoc`](base-browser-jsdoc.json) – combines `base-browser-bare` and `base-jsdoc` for Browser+JSDoc
+
+### Browser specific ones
+
+* [`browser`](browser.json) – main browser config, replicates `base-browser-jsdoc`
 
 ### Node specific ones
 
-These extends `base-node-jsdoc` with the correct [`lib`](https://www.typescriptlang.org/tsconfig#lib), [`module`](https://www.typescriptlang.org/tsconfig#module), [`moduleResolution`](https://www.typescriptlang.org/tsconfig#moduleResolution) and [`target`](https://www.typescriptlang.org/tsconfig#target) for each Node.js version.
+These extend `base-node-jsdoc` with the correct [`lib`](https://www.typescriptlang.org/tsconfig#lib), [`module`](https://www.typescriptlang.org/tsconfig#module), [`moduleResolution`](https://www.typescriptlang.org/tsconfig#moduleResolution) and [`target`](https://www.typescriptlang.org/tsconfig#target) for each Node.js version.
 
 Inspired by [tsconfig/bases](https://github.com/tsconfig/bases).
 

--- a/base-browser-bare.json
+++ b/base-browser-bare.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Base Browser Bare",
+
+  "extends": "./base-node-bare.json",
+
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "types": []
+  }
+}

--- a/base-browser-jsdoc.json
+++ b/base-browser-jsdoc.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Base Node.js JSDoc",
+  "display": "Base Browser JSDoc",
 
   "extends": [
-    "./base-node-bare.json",
+    "./base-browser-bare.json",
     "./base-jsdoc.json"
   ]
 }

--- a/base-jsdoc.json
+++ b/base-jsdoc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Base JSDoc",
+
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "maxNodeModuleJsDepth": 0, // Fix when used with jsconfig.json, see https://github.com/voxpelli/types-in-js/discussions/25
+    "noEmit": true,
+    "resolveJsonModule": true
+  }
+}

--- a/browser.json
+++ b/browser.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Browser",
+
+  "extends": "./base-browser-jsdoc.json",
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "base*.json",
+    "browser*.json",
     "node*.json"
   ],
   "scripts": {


### PR DESCRIPTION
This pull request introduces a new set of TypeScript configuration files to better support browser environments, reorganizes the base configs for improved clarity and reuse, and updates documentation to reflect these changes. The main focus is on modularizing JSDoc-related options and providing dedicated browser base configurations, making it easier to extend and combine configs for different use cases.

**Config structure and modularization:**

* Added `base-jsdoc.json` to centralize JSDoc-related TypeScript options, allowing both Node and Browser configs to share these settings. (`base-jsdoc.json` [base-jsdoc.jsonR1-R12](diffhunk://#diff-ce98a2c1e3b6132ca121fb23ab70d89f329276ee763e8f03986b7566912da2cfR1-R12))
* Refactored `base-node-jsdoc.json` to extend both `base-node-bare.json` and the new `base-jsdoc.json`, removing duplicated options. (`base-node-jsdoc.json` [base-node-jsdoc.jsonL5-R8](diffhunk://#diff-501dbe0aeef8dc2118cf0e46799b9120aab22b4141206cccb0c0d14eae37bd57L5-R8))

**Browser environment support:**

* Introduced `base-browser-bare.json` as a minimal browser-focused base config, extending `base-node-bare.json` and setting appropriate `lib` options. (`base-browser-bare.json` [base-browser-bare.jsonR1-R11](diffhunk://#diff-80abee86ea435dac92775a721bca165612b5880b9bced89d767c636e90e8580fR1-R11))
* Added `base-browser-jsdoc.json` to combine browser base and JSDoc options, and created a main `browser.json` config extending this setup. (`base-browser-jsdoc.json` [[1]](diffhunk://#diff-57740fbe6d2f19959b9d5104c5cec620abf8d0727ad76a501914c2fc52b50794R1-R9) `browser.json` [[2]](diffhunk://#diff-c480fb5d6896d559c583fe470842d61abc85003aa9d05b1375e873d215472467R1-R6)

**Documentation and packaging:**

* Updated `README.md` to document the new config structure, clarify naming, and explain the relationship between base, browser, and node configs. (README.md [README.mdR31-R48](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R48))
* Updated `package.json` to include the new browser config files in the published package. (`package.json` [package.jsonR17](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17))