### PR TITLE
feat: add TypeScript 7 support

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -105,20 +105,18 @@ jobs:
 
       - run: npx tsc
         working-directory: ./project
-  test_tsgo:
+  test_typescript_7:
     needs: lint
-    name: Validate with tsgo (TS 7)
+    name: Validate with TypeScript 7
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
-      - run: npm install --ignore-scripts
-      - run: npm install @typescript/native-preview
-      - run: npx tsgo --version
-      - run: npx tsgo
+      - run: npm ci --ignore-scripts
+      - run: npx tsc --version
+      - run: npm test
   test_external_completed:
     needs: test_external
     name: Tests completed

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ Inspired by [tsconfig/bases](https://github.com/tsconfig/bases).
 
 ## TypeScript compatibility
 
-This package supports TypeScript 5.9 and 6.0.
+This package supports TypeScript 5.9, 6.0, and 7.0.
 
 TypeScript 6.0 changed many defaults (`strict`, `esModuleInterop`, `allowSyntheticDefaultImports`, `noUncheckedSideEffectImports` are now all `true` by default; `types` defaults to `[]`). Since these configs already set these options explicitly, **users of this package are unaffected by TS 6.0's default changes**.
 
 Some explicit options are now redundant in TS 6.0 but are kept for backward compatibility with TS 5.9. They will be removed when TS 5.9 support is dropped. Similarly, `es2025` lib will be adopted in `node22`/`node24` configs once TS 5.9 is dropped (since `es2025` is only available from TS 6.0).
 
-TypeScript 6.0 is the last JS-based compiler release. TypeScript 7.0 (`tsgo`) is a native Go port with 10x faster type-checking. CI includes a `tsgo` validation job for forward-compatibility testing.
+TypeScript 6.0 is the last JS-based compiler release. TypeScript 7.0 is the native compiler release, and is the version used to develop and validate all configs in this package. The explicit options retained for TypeScript 5.9 compatibility are also accepted by TypeScript 7.0.
 
 ## Can I use this in my own project?
 

--- a/TS7_PLAN.md
+++ b/TS7_PLAN.md
@@ -4,7 +4,7 @@
 
 TypeScript 7.0 is the native Go-based rewrite of the TypeScript compiler ("tsgo"). It reached stable release on January 15, 2026, and is available as both `typescript@7.0.x` and `@typescript/native-preview`. This document evaluates what TS 7.0 means for `@voxpelli/tsconfig` and what actions to take.
 
-The repo currently supports `typescript ~5.9.0 || ~6.0.0` with `devDependencies` on `~6.0.0`.
+The repo supports `typescript ~5.9.0 || ~6.0.0 || ~7.0.0` with `devDependencies` on `~7.0.0`.
 
 ---
 
@@ -21,8 +21,8 @@ None of the options removed in TS 7.0 are present: no `baseUrl`, `outFile`, `mod
 **S3: JSDoc-first, noEmit design.**
 Since all configs set `noEmit: true`, the repo is immune to tsgo's incomplete emit limitations (declaration emit, downlevel emit). Type-checking — tsgo's strongest capability (~99.97% parity) — is the only thing that matters here.
 
-**S4: CI already tests with tsgo.**
-The `external.yml` workflow has a `test_tsgo` job with `continue-on-error: true`, providing forward-compatibility signal.
+**S4: CI tests every config with TypeScript 7.**
+The `external.yml` workflow installs the locked TypeScript 7 release and treats validation failures as blocking.
 
 **S5: Node version configs pin `moduleResolution: "node16"`.**
 This avoids any drift if `nodenext` changes meaning in future TS versions.
@@ -52,11 +52,11 @@ TS 7.0 uses deterministic content-based type ordering (always-on). Users generat
 **O1: Drop TS 5.9, clean up redundant options.**
 Removing TS 5.9 support enables: removing `esModuleInterop: true`, `allowSyntheticDefaultImports: true`, `noUncheckedSideEffectImports: true` (all defaults in TS 6.0+), and switching node22/24 libs to `["es2025"]`.
 
-**O2: Add `~7.0.0` to peerDependencies.**
-Signals official tsgo support. Unblocks users who want to install without peer dep warnings.
+**O2: Declare `~7.0.0` in peerDependencies.**
+The peer range now signals official TypeScript 7 support and avoids warnings for users on the stable native compiler.
 
-**O3: Expand tsgo CI testing.**
-Test each config individually (not just `node18.json` via root tsconfig) to catch per-config issues.
+**O3: Keep TypeScript 7 CI coverage comprehensive.**
+Each config is parsed individually in addition to checking the root `node18.json`-based config.
 
 **O4: Add `node26.json` preset.**
 Node 26 expected April 2026. Clean config with `lib: ["es2025"]`, `target: "es2025"`.
@@ -70,8 +70,8 @@ Node 18 reached EOL April 2025. Update root `tsconfig.json` to extend `node20` o
 **O7: Add migration guidance to README.**
 Document TS 6.0 → 7.0 migration path: no `ignoreDeprecations`, type ordering diffs, glob resolution issue, JSDoc tag changes.
 
-**O8: Consider tsgo as primary dev dependency.**
-10x faster CI. Keep TS 6.0 in peerDeps for backward compatibility.
+**O8: Use TypeScript 7 as the primary dev dependency.**
+The stable native compiler is now used for local and CI validation, while TypeScript 5.9 and 6.0 remain in peerDependencies for backward compatibility.
 
 ### Threats — External risks to watch
 
@@ -101,7 +101,7 @@ If `nodenext` evolves differently in tsgo, the pinned `moduleResolution: "node16
 
 | # | Action | Effort | Impact |
 |---|--------|--------|--------|
-| 1 | Expand tsgo CI to test **each config** individually | Low | Medium |
+| 1 | ✅ Expand TypeScript 7 CI to test **each config** individually | Low | Medium |
 | 2 | Investigate JSDoc behavioral diffs by running tsgo against downstream projects | Medium | High |
 | 3 | Document known TS 7.0 migration notes in README | Medium | Medium |
 
@@ -118,9 +118,9 @@ If `nodenext` evolves differently in tsgo, the pinned `moduleResolution: "node16
 
 | # | Action | Effort | Impact |
 |---|--------|--------|--------|
-| 8 | Add `~7.0.0` to peerDependencies | Low | High |
-| 9 | Remove `continue-on-error: true` from tsgo CI job | Low | Medium |
-| 10 | Consider tsgo as primary devDependency | Low | Medium |
+| 8 | ✅ Add `~7.0.0` to peerDependencies | Low | High |
+| 9 | ✅ Remove `continue-on-error: true` from TypeScript 7 CI job | Low | Medium |
+| 10 | ✅ Use TypeScript 7 as the primary devDependency | Low | Medium |
 
 ### Phase 4: Forward-looking
 
@@ -134,11 +134,11 @@ If `nodenext` evolves differently in tsgo, the pinned `moduleResolution: "node16
 
 ## Key Decision Points
 
-1. **When to add TS 7.0 to peerDeps?** After confirming all configs pass `tsgo` validation without errors (CI job currently allows failure).
+1. **When to add TS 7.0 to peerDeps?** Done after confirming all configs parse and the root project passes with TypeScript 7.
 
 2. **When to drop TS 5.9?** Natural point is the next major version (v18.0.0). This unblocks Phase 2 actions.
 
-3. **When to make tsgo the primary dev dependency?** When declaration emit and JSDoc checking reach full parity. Currently risky for a JSDoc-first package due to T1.
+3. **When to make TypeScript 7 the primary dev dependency?** Done once the stable `typescript@7` package was available and all published configs passed validation. Consumers can still select TypeScript 5.9 or 6.0 through the peer range.
 
 4. **How to handle JSDoc behavioral differences?** Test downstream projects with tsgo, document known differences, and file issues on microsoft/typescript-go for regressions affecting JSDoc patterns.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,14 @@
         "husky": "^9.1.7",
         "list-dependents-cli": "^2.7.1",
         "npm-run-all2": "^8.0.4",
-        "typescript": "~6.0.0",
+        "typescript": "~7.0.0",
         "validate-conventional-commit": "^1.0.4"
       },
       "engines": {
         "typescript": ">=5.9"
       },
       "peerDependencies": {
-        "typescript": "~5.9.0 || ~6.0.0"
+        "typescript": "~5.9.0 || ~6.0.0 || ~7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -132,6 +132,346 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@voxpelli/semver-set": {
       "version": "6.0.2",
@@ -2430,17 +2770,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -19,26 +19,27 @@
   ],
   "scripts": {
     "check": "tsc",
+    "check:configs": "for config in base*.json browser*.json node*.json; do tsc --showConfig -p \"$config\" > /dev/null || exit; done",
     "dependents:0-update": "cd dependents-data/ && list-dependents list --precision=3 --min-downloads=10 --field engines --include-historic -n @voxpelli/tsconfig",
     "dependents:1-filter": "list-dependents filter --sort-download --min-downloads=0 --repository-prefix=https://github.com/ -i dependents-data/voxpelli__tsconfig.ndjson  | jq -s '[.[].repositoryUrl | sub(\"https://github.com/\";\"\";\"i\")] | unique | sort' > dependents-data/source-automatic.json",
     "dependents:2-join": "jq -s '[.[].[]] | unique | sort as $all | $all - [$exclude.[].[].[]]' dependents-data/source-*.json --slurpfile exclude dependents-data/failures.json > dependents-data/joined.json",
     "dependents-dedupe-manual": "jq '. as $all | $all - $exclude.[]' dependents-data/source-manual.json --slurpfile exclude dependents-data/source-automatic.json",
     "dependents": "run-s dependents:*",
     "prepare": "husky",
-    "test": "tsc"
+    "test": "run-p check check:configs"
   },
   "devDependencies": {
     "@types/node": "^22.19.17",
     "husky": "^9.1.7",
     "list-dependents-cli": "^2.7.1",
     "npm-run-all2": "^8.0.4",
-    "typescript": "~6.0.0",
+    "typescript": "~7.0.0",
     "validate-conventional-commit": "^1.0.4"
   },
   "engines": {
     "typescript": ">=5.9"
   },
   "peerDependencies": {
-    "typescript": "~5.9.0 || ~6.0.0"
+    "typescript": "~5.9.0 || ~6.0.0 || ~7.0.0"
   }
 }


### PR DESCRIPTION
## What changed

- add TypeScript 7 to the supported peer dependency range
- use the latest stable TypeScript 7 release for development and validation
- validate every published config, not only the root config
- make TypeScript 7 CI blocking now that the stable compiler is available
- update the compatibility docs and preparedness plan

## Why

TypeScript 7 is now stable, but this package still declared support only through TypeScript 6 and validated TS7 through the older native-preview package as a non-blocking check. This brings the package metadata, lockfile, tests, CI, and docs in line with the stable release while preserving TypeScript 5.9 and 6.0 compatibility for consumers.

## Validation

- `npm ci --ignore-scripts`
- `npm test`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`

## Review note

This PR has not been reviewed by a human yet. I will hand-review it as soon as possible.
